### PR TITLE
Filter temporary and hidden files

### DIFF
--- a/VideoGPSRecorder/VideoGPSRecorder/MediaGridView.swift
+++ b/VideoGPSRecorder/VideoGPSRecorder/MediaGridView.swift
@@ -68,8 +68,8 @@ class MediaGridViewModel: ObservableObject {
                 let contents = try fileManager.contentsOfDirectory(
                     at: tempDirectory,
                     includingPropertiesForKeys: [.creationDateKey, .fileSizeKey],
-                    options: []
-                )
+                    options: [.skipsHiddenFiles]
+                ).filter { !$0.lastPathComponent.hasSuffix(".tmp") }
                 
                 let items = contents.compactMap { url -> MediaItem? in
                     guard let type = mediaType(for: url) else { return nil }


### PR DESCRIPTION
## Summary
- ignore hidden and `.tmp` files when loading media files

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684bbe0ba2c8832bb59fcd68486c3fca